### PR TITLE
Add support for CJK characters

### DIFF
--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubApiClient.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/api/GithubApiClient.java
@@ -170,7 +170,7 @@ public class GithubApiClient {
                 request.releaseConnection();
                 throw new GithubAuthenticationException("Authentication failed.");
             }
-            return new InputStreamReader(response.getEntity().getContent());
+            return new InputStreamReader(response.getEntity().getContent(), "UTF-8");
         } catch (IOException e) {
             request.releaseConnection();
             throw new GithubAuthenticationException(e);


### PR DESCRIPTION
I've found some org/teams are not mapped into roles if they have CJK characters in their name. This PR adds support for CJK characters(or even unicode characters) in org/team names.